### PR TITLE
Fix mobile CSS: quiz counter overlap and navbar profile visibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -731,11 +731,13 @@ a {
         display: flex;
     }
     
-    .nav-cta {
+    .nav-cta,
+    .nav-cta:not(.hidden) {
         display: none !important;
     }
-    
-    .user-dropdown {
+
+    .user-dropdown,
+    .user-dropdown:not(.hidden) {
         display: none !important;
     }
     
@@ -825,21 +827,6 @@ a {
         flex-direction: column;
         gap: 40px;
         text-align: center;
-    }
-    
-    /* Quiz mobile */
-    .quiz-container {
-        padding: 0 20px;
-    }
-    
-    .quiz-card {
-        padding: 32px 24px;
-    }
-    
-    .question-counter {
-        position: static;
-        display: inline-block;
-        margin-bottom: 20px;
     }
     
     .options-list {
@@ -1598,6 +1585,7 @@ body:has(.login-form) .hero-glow {
     font-weight: 500;
     margin-bottom: 24px;
     color: #fff;
+    padding-right: 90px;
 }
 
 .options {
@@ -1685,6 +1673,40 @@ body:has(.login-form) .hero-glow {
     height: 100%;
     background: linear-gradient(90deg, #38bdf8, #0ea5e9);
     transition: width 0.3s ease;
+}
+
+@media (max-width: 768px) {
+    .quiz-container {
+        padding: 0 16px;
+    }
+
+    .quiz-card {
+        padding: 24px 16px;
+    }
+
+    .question-counter {
+        position: static;
+        display: inline-block;
+        margin-bottom: 16px;
+    }
+
+    .question {
+        font-size: 1.1rem;
+        padding-right: 0;
+    }
+
+    .quiz-buttons {
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .quiz-result h2 {
+        font-size: 1.5rem;
+    }
+
+    .quiz-result p {
+        font-size: 1rem;
+    }
 }
 
 


### PR DESCRIPTION
- Move quiz mobile styles after base styles so they aren't overridden
- Fix question-counter absolute positioning on mobile
- Add padding-right to .question on desktop to prevent counter overlap
- Fix user-dropdown and nav-cta specificity so they stay hidden on mobile